### PR TITLE
Fix 401 when fetching providers

### DIFF
--- a/src/controllers/homeController.ts
+++ b/src/controllers/homeController.ts
@@ -8,7 +8,12 @@ export default class HomeController {
   @Authorized()
   async getAll(@Req() req) {
     const user = req.user;
-    const providers = user ? await new ManageApiService(req.user.access_token).getProviders() : null;
+    let providers = [];
+    try {
+      providers = user ? await new ManageApiService(req.user.access_token).getProviders() : null;
+    } catch (err) {
+      console.log("Error fetching providers:", err);
+    }
     return {
       displayName: user ? `${user["given_name"]} ${user["family_name"]}` : "",
       user,


### PR DESCRIPTION
If the endpoint fails for any reason, you get no logs and an error message on the frontend saying `Cannot get /`.